### PR TITLE
Make Settings Toggle Available to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,16 +175,18 @@ Use the provided `useConsent` hook to access or update the current consent and s
 import { useConsent } from 'react-hook-consent';
 
 // ...
-const { consent, setConsent, isBannerVisible, toggleBanner } = useConsent();
+const { consent, setConsent, isBannerVisible, toggleBanner, isDetailsVisible, toggleDetails } = useConsent();
 // ...
 ```
 
 #### Return
 
-| Object Name     | Type                         | Description                                         |
-| --------------- | ---------------------------- | --------------------------------------------------- |
-| consent         | Consent[]                    | Services which have been consent to                 |
-| hasConsent      | (id: Consent) => boolean     | Get consent state of specific id                    |
-| isBannerVisible | boolean                      | Indicates if consent banner is visible              |
-| toggleBanner    | () => void                   | Shows or hides the consent banner                   |
-| setConsent      | (consent: Consent[]) => void | Update consent by providing consent ids to be saved |
+| Object Name      | Type                         | Description                                         |
+| ---------------- | ---------------------------- | --------------------------------------------------- |
+| consent          | Consent[]                    | Services which have been consent to                 |
+| hasConsent       | (id: Consent) => boolean     | Get consent state of specific id                    |
+| isBannerVisible  | boolean                      | Indicates if consent banner is visible              |
+| toggleBanner     | () => void                   | Shows or hides the consent banner                   |
+| setConsent       | (consent: Consent[]) => void | Update consent by providing consent ids to be saved |
+| isDetailsVisible | boolean                      | Indicates if details / settings modal is visible    |
+| toggleDetails    | () => void                   | Shows or hides the details / settings modal         |

--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -26,6 +26,8 @@ type ConsentContext = {
     hasConsent: (consent: Consent) => boolean;
     isBannerVisible: boolean;
     toggleBanner: () => void;
+    isDetailsVisible: boolean;
+    toggleDetails: () => void;
     setConsent: (consent: Consent[]) => void;
     options: ConsentOptions;
 };
@@ -33,8 +35,10 @@ type ConsentContext = {
 export const ConsentContext = React.createContext<ConsentContext>({
     consent: [],
     isBannerVisible: true,
+    isDetailsVisible: false,
     hasConsent: () => true,
     toggleBanner: () => {},
+    toggleDetails: () => {},
     setConsent: ([]) => {},
     options: { services: [] },
 });

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -7,10 +7,22 @@ type ConsentProviderProps = {
 };
 
 export function ConsentProvider({ options, children }: ConsentProviderProps) {
-    const { consent, hasConsent, isBannerVisible, toggleBanner, setConsent } = useConsentState(options);
+    const { consent, hasConsent, isBannerVisible, toggleBanner, isDetailsVisible, toggleDetails, setConsent } =
+        useConsentState(options);
 
     return (
-        <ConsentContext.Provider value={{ consent, hasConsent, isBannerVisible, toggleBanner, setConsent, options }}>
+        <ConsentContext.Provider
+            value={{
+                consent,
+                hasConsent,
+                isBannerVisible,
+                toggleBanner,
+                isDetailsVisible,
+                toggleDetails,
+                setConsent,
+                options,
+            }}
+        >
             {children}
         </ConsentContext.Provider>
     );

--- a/src/banner/Banner.tsx
+++ b/src/banner/Banner.tsx
@@ -22,9 +22,11 @@ type ConsentBannerProps = {
 export function ConsentBanner({ children, settings, approve, decline }: ConsentBannerProps) {
     const {
         isBannerVisible,
+        isDetailsVisible,
+        toggleDetails,
         options: { theme },
     } = useConsent();
-    const { onDecline, onApprove, onDetailsToggle, isDetailsVisible } = useConsentBannerActions();
+    const { onDecline, onApprove } = useConsentBannerActions();
 
     return (
         <>
@@ -42,7 +44,7 @@ export function ConsentBanner({ children, settings, approve, decline }: ConsentB
                             )}
                         </div>
                         {settings?.hidden ? null : (
-                            <button className="rhc-banner__content__secondary" onClick={onDetailsToggle}>
+                            <button className="rhc-banner__content__secondary" onClick={toggleDetails}>
                                 {settings?.label ? settings.label : <>Settings</>}
                             </button>
                         )}
@@ -58,7 +60,7 @@ export function ConsentBanner({ children, settings, approve, decline }: ConsentB
                 </div>
             )}
 
-            {isDetailsVisible && <ConsentBannerSettings onToggle={onDetailsToggle} modal={settings?.modal} />}
+            {isDetailsVisible && <ConsentBannerSettings onToggle={toggleDetails} modal={settings?.modal} />}
         </>
     );
 }

--- a/src/banner/settings/Settings.tsx
+++ b/src/banner/settings/Settings.tsx
@@ -21,7 +21,7 @@ export type ConsentBannerSettingsModal = {
 
 type ConsentBannerSettingsProps = { onToggle: () => void; modal?: ConsentBannerSettingsModal };
 
-export function ConsentBannerSettings({ onToggle, modal }: ConsentBannerSettingsProps) {
+export function ConsentBannerSettings({ onToggle = () => {}, modal }: ConsentBannerSettingsProps) {
     const {
         options: { services, theme },
     } = useConsent();

--- a/src/banner/useConsentBannerActions.test.tsx
+++ b/src/banner/useConsentBannerActions.test.tsx
@@ -8,6 +8,7 @@ const options = {
         { id: 'service2', name: 'Service 2' },
     ],
 };
+
 const mockSetConsent = jest.fn();
 
 jest.mock('../useConsent', () => {
@@ -55,23 +56,5 @@ describe('useConsentBannerActions', () => {
         });
 
         expect(mockSetConsent).toHaveBeenCalledWith([]);
-    });
-
-    it('should toggle showDetails state when onDetailsToggle is called', () => {
-        const { result } = renderHook(() => useConsentBannerActions(), {
-            wrapper: ({ children }) => <ConsentProvider options={options}>{children}</ConsentProvider>,
-        });
-
-        expect(result.current.isDetailsVisible).toBe(false);
-
-        act(() => {
-            result.current.onDetailsToggle();
-        });
-        expect(result.current.isDetailsVisible).toBe(true);
-
-        act(() => {
-            result.current.onDetailsToggle();
-        });
-        expect(result.current.isDetailsVisible).toBe(false);
     });
 });

--- a/src/banner/useConsentBannerActions.tsx
+++ b/src/banner/useConsentBannerActions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { Consent } from '../Context';
 import { useConsent } from '../useConsent';
 
@@ -6,9 +6,9 @@ export function useConsentBannerActions() {
     const {
         setConsent,
         options: { services },
+        isDetailsVisible,
+        toggleDetails,
     } = useConsent();
-
-    const [showDetails, setShowDetails] = useState(false);
 
     const onApprove = useCallback(
         (approved?: Consent[]) => {
@@ -22,8 +22,8 @@ export function useConsentBannerActions() {
     }, [setConsent]);
 
     const onDetailsToggle = useCallback(() => {
-        setShowDetails((details) => !details);
+        toggleDetails();
     }, []);
 
-    return { onDecline, onApprove, onDetailsToggle, isDetailsVisible: showDetails };
+    return { onDecline, onApprove, onDetailsToggle, isDetailsVisible: isDetailsVisible };
 }

--- a/src/banner/useConsentBannerActions.tsx
+++ b/src/banner/useConsentBannerActions.tsx
@@ -6,8 +6,6 @@ export function useConsentBannerActions() {
     const {
         setConsent,
         options: { services },
-        isDetailsVisible,
-        toggleDetails,
     } = useConsent();
 
     const onApprove = useCallback(
@@ -21,9 +19,5 @@ export function useConsentBannerActions() {
         setConsent([]);
     }, [setConsent]);
 
-    const onDetailsToggle = useCallback(() => {
-        toggleDetails();
-    }, []);
-
-    return { onDecline, onApprove, onDetailsToggle, isDetailsVisible: isDetailsVisible };
+    return { onDecline, onApprove };
 }

--- a/src/core/local-storage/get.test.ts
+++ b/src/core/local-storage/get.test.ts
@@ -13,13 +13,13 @@ describe('getFromLocalStorage', () => {
 
         const result = getFromLocalStorage(hash);
 
-        expect(result).toEqual({ consent, isBannerVisible: false });
+        expect(result).toEqual({ consent, isBannerVisible: false, isDetailsVisible: false });
     });
 
     test('should return the correct data when local storage is empty', () => {
         const result = getFromLocalStorage('abc123');
 
-        expect(result).toEqual({ consent: [], isBannerVisible: true });
+        expect(result).toEqual({ consent: [], isBannerVisible: true, isDetailsVisible: false });
     });
 
     test('should return the correct data when hash is different', () => {
@@ -27,6 +27,6 @@ describe('getFromLocalStorage', () => {
 
         const result = getFromLocalStorage('abc123');
 
-        expect(result).toEqual({ consent: [], isBannerVisible: true });
+        expect(result).toEqual({ consent: [], isBannerVisible: true, isDetailsVisible: false });
     });
 });

--- a/src/core/local-storage/get.ts
+++ b/src/core/local-storage/get.ts
@@ -7,15 +7,16 @@ export function getFromLocalStorage(hash: string) {
     const item = localStorage.getItem(`${localStorageKey}`);
 
     if (!item) {
-        return { consent: [], isBannerVisible: true };
+        return { consent: [], isBannerVisible: true, isDetailsVisible: false };
     }
 
     const { consent, hash: storedHash } = JSON.parse(item) as StoredState;
 
     let isBannerVisible = false;
+    let isDetailsVisible = false;
     if (storedHash !== hash) {
         isBannerVisible = true;
     }
 
-    return { consent: consent && consent.length > 0 ? consent : [], isBannerVisible };
+    return { consent: consent && consent.length > 0 ? consent : [], isBannerVisible, isDetailsVisible };
 }

--- a/src/useConsent.test.tsx
+++ b/src/useConsent.test.tsx
@@ -1,0 +1,30 @@
+import { act, renderHook } from '@testing-library/react';
+import { ConsentProvider } from './Provider';
+import { useConsent } from './useConsent';
+
+const options = {
+    services: [
+        { id: 'service1', name: 'Service 1' },
+        { id: 'service2', name: 'Service 2' },
+    ],
+};
+
+describe('useConsent', () => {
+    it('should toggle isDetailsVisible state when toggleDetails is called', () => {
+        const { result } = renderHook(() => useConsent(), {
+            wrapper: ({ children }) => <ConsentProvider options={options}>{children}</ConsentProvider>,
+        });
+
+        expect(result.current.isDetailsVisible).toBe(false);
+
+        act(() => {
+            result.current.toggleDetails();
+        });
+        expect(result.current.isDetailsVisible).toBe(true);
+
+        act(() => {
+            result.current.toggleDetails();
+        });
+        expect(result.current.isDetailsVisible).toBe(false);
+    });
+});

--- a/src/useConsentState.tsx
+++ b/src/useConsentState.tsx
@@ -6,12 +6,13 @@ import { getFromLocalStorage } from './core/local-storage/get';
 import { isValidInLocalStorage } from './core/local-storage/valid';
 import { updateServices } from './core/update-services';
 
-type ConsentState = { consent: Consent[]; isBannerVisible: boolean; hash: string };
+type ConsentState = { consent: Consent[]; isBannerVisible: boolean; isDetailsVisible: boolean; hash: string };
 
 export function useConsentState(options: ConsentOptions) {
     const [state, setState] = useState<ConsentState>({
         consent: [],
         isBannerVisible: false,
+        isDetailsVisible: false,
         hash: hash(options),
     });
 
@@ -19,13 +20,13 @@ export function useConsentState(options: ConsentOptions) {
         if (!isValidInLocalStorage(state.hash)) {
             const consent = options.services.map((service) => service.id);
 
-            setState((state) => ({ ...state, consent, isBannerVisible: true }));
+            setState((state) => ({ ...state, consent, isBannerVisible: true, isDetailsVisible: false }));
             return;
         }
 
-        const { consent, isBannerVisible } = getFromLocalStorage(state.hash);
+        const { consent, isBannerVisible, isDetailsVisible } = getFromLocalStorage(state.hash);
 
-        setState((state) => ({ ...state, consent, isBannerVisible }));
+        setState((state) => ({ ...state, consent, isBannerVisible, isDetailsVisible }));
 
         const approvedServices = options.services.filter((service) => consent.includes(service.id));
         addServices(approvedServices);
@@ -33,7 +34,7 @@ export function useConsentState(options: ConsentOptions) {
 
     const setConsent = useCallback(
         (consent: Consent[]) => {
-            setState((state) => ({ ...state, consent, isBannerVisible: false }));
+            setState((state) => ({ ...state, consent, isBannerVisible: false, isDetailsVisible: false }));
             updateServices(options, consent, state.hash);
         },
         [options, state.hash]
@@ -45,11 +46,17 @@ export function useConsentState(options: ConsentOptions) {
         setState((state) => ({ ...state, isBannerVisible: !state.isBannerVisible }));
     }, []);
 
+    const toggleDetails = useCallback(() => {
+        setState((state) => ({ ...state, isDetailsVisible: !state.isDetailsVisible }));
+    }, []);
+
     return {
         consent: state.consent,
         hasConsent,
         isBannerVisible: state.isBannerVisible,
+        isDetailsVisible: state.isDetailsVisible,
         toggleBanner,
+        toggleDetails,
         setConsent,
     };
 }

--- a/src/useConsentState.tsx
+++ b/src/useConsentState.tsx
@@ -18,7 +18,7 @@ export function useConsentState(options: ConsentOptions) {
 
     useEffect(() => {
         if (!isValidInLocalStorage(state.hash)) {
-            const consent = options.services.map((service) => service.id);
+            const consent = options.services.filter((service) => service?.mandatory).map((service) => service.id);
 
             setState((state) => ({ ...state, consent, isBannerVisible: true, isDetailsVisible: false }));
             return;

--- a/src/useConsentState.tsx
+++ b/src/useConsentState.tsx
@@ -34,7 +34,7 @@ export function useConsentState(options: ConsentOptions) {
 
     const setConsent = useCallback(
         (consent: Consent[]) => {
-            setState((state) => ({ ...state, consent, isBannerVisible: false, isDetailsVisible: false }));
+            setState((state) => ({ ...state, consent, isBannerVisible: false }));
             updateServices(options, consent, state.hash);
         },
         [options, state.hash]


### PR DESCRIPTION
First of all I like your way of thinking in creating this Package, thanks for creating it!
Fell into a rabbit hole when looking for GDPR banners without having to use an external service
and settled on yours : ).

This PR will move toggling the Details / Settings Modal to `useConsentState` in order to make it available
as `isDetailsVisible` & `toggleDetails()` to a Developer.
And while you seem to have made all Services being auto enabled by default in one of your last commits,
to my knowledge that's against the GDPR and a dark pattern. So I changed it to only make the mandatory
ones auto enabled.

Hope the changes are to your liking and this PR will get merged.
Up till then I'm using the following patch with [patch-package](https://www.npmjs.com/package/patch-package)
(has to be renamed to `.patch` & put into a `patches` folder - for whatever reason GitHub doesn't support patch files % ):
 
[react-hook-consent+3.2.0.txt](https://github.com/lukaskupczyk/react-hook-consent/files/11497952/react-hook-consent%2B3.2.0.txt)

Best,

Tim.